### PR TITLE
refactor!: consistently use values instead of pointers

### DIFF
--- a/.github/workflows/fuzz.yaml
+++ b/.github/workflows/fuzz.yaml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Install Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
-        go-version: "1.20"
+        go-version: "1.21"
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Fuzz
       run: make fuzz

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -10,13 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
-          go-version: "1.20"
+          go-version: "1.21"
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3.2.0
+        uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.52
+          version: v1.54

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,16 +4,16 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.18.x, 1.19.x, 1.20.x]
+        go-version: [1.19.x, 1.20.x, 1.21.x]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Install Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
         go-version: ${{ matrix.go-version }}
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Test
       env:
         GO111MODULE: on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,72 +1,97 @@
+<!-- markdownlint-disable MD024 -->
 # Changelog
 
 ## 3.2.1 (2023-04-10)
 
 ### Changed
 
-- #198: Improved testing around pre-release names
-- #200: Improved code scanning with addition of CodeQL
-- #201: Testing now includes Go 1.20. Go 1.17 has been dropped
-- #202: Migrated Fuzz testing to Go built-in Fuzzing. CI runs daily
-- #203: Docs updated for security details
+- [#198](https://github.com/Masterminds/semver/issues/198):
+  Improved testing around pre-release names
+- [#200](https://github.com/Masterminds/semver/issues/200):
+  Improved code scanning with addition of CodeQL
+- [#201](https://github.com/Masterminds/semver/issues/201):
+  Testing now includes Go 1.20. Go 1.17 has been dropped
+- [#202](https://github.com/Masterminds/semver/issues/202):
+  Migrated Fuzz testing to Go built-in Fuzzing. CI runs daily
+- [#203](https://github.com/Masterminds/semver/issues/203):
+  Docs updated for security details
 
 ### Fixed
 
-- #199: Fixed issue with range transformations
+- [#199](https://github.com/Masterminds/semver/issues/199):
+  Fixed issue with range transformations
 
 ## 3.2.0 (2022-11-28)
 
 ### Added
 
-- #190: Added text marshaling and unmarshaling
-- #167: Added JSON marshalling for constraints (thanks @SimonTheLeg)
-- #173: Implement encoding.TextMarshaler and encoding.TextUnmarshaler on Version (thanks @MarkRosemaker)
-- #179: Added New() version constructor (thanks @kazhuravlev)
+- [#190](https://github.com/Masterminds/semver/issues/190):
+  Added text marshaling and unmarshaling
+- [#167](https://github.com/Masterminds/semver/issues/167):
+  Added JSON marshalling for constraints (thanks @SimonTheLeg)
+- [#173](https://github.com/Masterminds/semver/issues/173):
+  Implement encoding.TextMarshaler
+  and encoding.TextUnmarshaler on Version (thanks @MarkRosemaker)
+- [#179](https://github.com/Masterminds/semver/issues/179):
+  Added New() version constructor (thanks @kazhuravlev)
 
 ### Changed
 
-- #182/#183: Updated CI testing setup
+- [#182](https://github.com/Masterminds/semver/issues/182)/
+  [#183](https://github.com/Masterminds/semver/issues/183):
+  Updated CI testing setup
 
 ### Fixed
 
-- #186: Fixing issue where validation of constraint section gave false positives
-- #176: Fix constraints check with *-0 (thanks @mtt0)
-- #181: Fixed Caret operator (^) gives unexpected results when the minor version in constraint is 0 (thanks @arshchimni)
-- #161: Fixed godoc (thanks @afirth)
+- [#186](https://github.com/Masterminds/semver/issues/186):
+  Fixing issue where validation of constraint section gave false positives
+- [#176](https://github.com/Masterminds/semver/issues/176):
+  Fix constraints check with *-0 (thanks @mtt0)
+- [#181](https://github.com/Masterminds/semver/issues/181):
+  Fixed Caret operator (^) gives unexpected results
+  when the minor version in constraint is 0 (thanks @arshchimni)
+- [#161](https://github.com/Masterminds/semver/issues/161):
+  Fixed godoc (thanks @afirth)
 
 ## 3.1.1 (2020-11-23)
 
 ### Fixed
 
-- #158: Fixed issue with generated regex operation order that could cause problem
+- [#158](https://github.com/Masterminds/semver/issues/158):
+  Fixed issue with generated regex operation order that could cause problem
 
 ## 3.1.0 (2020-04-15)
 
 ### Added
 
-- #131: Add support for serializing/deserializing SQL (thanks @ryancurrah)
+- [#131](https://github.com/Masterminds/semver/issues/131):
+  Add support for serializing/deserializing SQL (thanks @ryancurrah)
 
 ### Changed
 
-- #148: More accurate validation messages on constraints
+- [#148](https://github.com/Masterminds/semver/issues/148):
+  More accurate validation messages on constraints
 
 ## 3.0.3 (2019-12-13)
 
 ### Fixed
 
-- #141: Fixed issue with <= comparison
+- [#141](https://github.com/Masterminds/semver/issues/141):
+  Fixed issue with <= comparison
 
 ## 3.0.2 (2019-11-14)
 
 ### Fixed
 
-- #134: Fixed broken constraint checking with ^0.0 (thanks @krmichelos)
+- [#134](https://github.com/Masterminds/semver/issues/134):
+  Fixed broken constraint checking with ^0.0 (thanks @krmichelos)
 
 ## 3.0.1 (2019-09-13)
 
 ### Fixed
 
-- #125: Fixes issue with module path for v3
+- [#125](https://github.com/Masterminds/semver/issues/125):
+  Fixes issue with module path for v3
 
 ## 3.0.0 (2019-09-12)
 
@@ -87,7 +112,7 @@ functions. These are described in the added and changed sections below.
   and uses fewer allocations than NewVersion.
 - Fuzzing has been performed on NewVersion, StrictNewVersion, and NewConstraint.
   The Makefile contains the operations used. For more information on you can start
-  on Wikipedia at https://en.wikipedia.org/wiki/Fuzzing
+  on Wikipedia at <https://en.wikipedia.org/wiki/Fuzzing>
 - Now using Go modules
 
 ### Changed
@@ -107,98 +132,124 @@ functions. These are described in the added and changed sections below.
 
 ### Added
 
-- #103: Add basic fuzzing for `NewVersion()` (thanks @jesse-c)
+- [#103](https://github.com/Masterminds/semver/issues/103):
+  Add basic fuzzing for `NewVersion()` (thanks @jesse-c)
 
 ### Changed
 
-- #82: Clarify wildcard meaning in range constraints and update tests for it (thanks @greysteil)
-- #83: Clarify caret operator range for pre-1.0.0 dependencies (thanks @greysteil)
-- #72: Adding docs comment pointing to vert for a cli
-- #71: Update the docs on pre-release comparator handling
-- #89: Test with new go versions (thanks @thedevsaddam)
-- #87: Added $ to ValidPrerelease for better validation (thanks @jeremycarroll)
+- [#82](https://github.com/Masterminds/semver/issues/82):
+  Clarify wildcard meaning in range constraints and update tests for it (thanks @greysteil)
+- [#83](https://github.com/Masterminds/semver/issues/83):
+  Clarify caret operator range for pre-1.0.0 dependencies (thanks @greysteil)
+- [#72](https://github.com/Masterminds/semver/issues/72):
+  Adding docs comment pointing to vert for a cli
+- [#71](https://github.com/Masterminds/semver/issues/71):
+  Update the docs on pre-release comparator handling
+- [#89](https://github.com/Masterminds/semver/issues/89):
+  Test with new go versions (thanks @thedevsaddam)
+- [#87](https://github.com/Masterminds/semver/issues/87):
+  Added $ to ValidPrerelease for better validation (thanks @jeremycarroll)
 
 ### Fixed
 
-- #78: Fix unchecked error in example code (thanks @ravron)
-- #70: Fix the handling of pre-releases and the 0.0.0 release edge case
-- #97: Fixed copyright file for proper display on GitHub
-- #107: Fix handling prerelease when sorting alphanum and num 
-- #109: Fixed where Validate sometimes returns wrong message on error
+- [#78](https://github.com/Masterminds/semver/issues/78):
+  Fix unchecked error in example code (thanks @ravron)
+- [#70](https://github.com/Masterminds/semver/issues/70):
+  Fix the handling of pre-releases and the 0.0.0 release edge case
+- [#97](https://github.com/Masterminds/semver/issues/97):
+  Fixed copyright file for proper display on GitHub
+- [#107](https://github.com/Masterminds/semver/issues/107):
+  Fix handling prerelease when sorting alphanum and num
+- [#109](https://github.com/Masterminds/semver/issues/109):
+  Fixed where Validate sometimes returns wrong message on error
 
 ## 1.4.2 (2018-04-10)
 
 ### Changed
 
-- #72: Updated the docs to point to vert for a console appliaction
-- #71: Update the docs on pre-release comparator handling
+- [#72](https://github.com/Masterminds/semver/issues/72):
+  Updated the docs to point to vert for a console appliaction
+- [#71](https://github.com/Masterminds/semver/issues/71):
+  Update the docs on pre-release comparator handling
 
 ### Fixed
 
-- #70: Fix the handling of pre-releases and the 0.0.0 release edge case
+- [#70](https://github.com/Masterminds/semver/issues/70):
+  Fix the handling of pre-releases and the 0.0.0 release edge case
 
 ## 1.4.1 (2018-04-02)
 
 ### Fixed
 
-- Fixed #64: Fix pre-release precedence issue (thanks @uudashr)
+- Fixed [#64](https://github.com/Masterminds/semver/issues/64):
+  Fix pre-release precedence issue (thanks @uudashr)
 
 ## 1.4.0 (2017-10-04)
 
 ### Changed
 
-- #61: Update NewVersion to parse ints with a 64bit int size (thanks @zknill)
+- [#61](https://github.com/Masterminds/semver/issues/61):
+  Update NewVersion to parse ints with a 64bit int size (thanks @zknill)
 
 ## 1.3.1 (2017-07-10)
 
 ### Fixed
 
-- Fixed #57: number comparisons in prerelease sometimes inaccurate
+- Fixed [#57](https://github.com/Masterminds/semver/issues/57):
+  number comparisons in prerelease sometimes inaccurate
 
 ## 1.3.0 (2017-05-02)
 
 ### Added
 
-- #45: Added json (un)marshaling support (thanks @mh-cbon)
-- Stability marker. See https://masterminds.github.io/stability/
+- [#45](https://github.com/Masterminds/semver/issues/45):
+  Added json (un)marshaling support (thanks @mh-cbon)
+- Stability marker. See <https://wfscheper.github.io/stability/>
 
 ### Fixed
 
-- #51: Fix handling of single digit tilde constraint (thanks @dgodd)
+- [#51](https://github.com/Masterminds/semver/issues/51):
+  Fix handling of single digit tilde constraint (thanks @dgodd)
 
 ### Changed
 
-- #55: The godoc icon moved from png to svg
+- [#55](https://github.com/Masterminds/semver/issues/55):
+  The godoc icon moved from png to svg
 
 ## 1.2.3 (2017-04-03)
 
 ### Fixed
 
-- #46: Fixed 0.x.x and 0.0.x in constraints being treated as *
+- [#46](https://github.com/Masterminds/semver/issues/46):
+  Fixed 0.x.x and 0.0.x in constraints being treated as *
 
 ## Release 1.2.2 (2016-12-13)
 
 ### Fixed
 
-- #34: Fixed issue where hyphen range was not working with pre-release parsing.
+- [#34](https://github.com/Masterminds/semver/issues/34):
+  Fixed issue where hyphen range was not working with pre-release parsing.
 
 ## Release 1.2.1 (2016-11-28)
 
 ### Fixed
 
-- #24: Fixed edge case issue where constraint "> 0" does not handle "0.0.1-alpha"
-  properly.
+- [#24](https://github.com/Masterminds/semver/issues/24):
+  Fixed edge case issue where constraint "> 0" does not handle "0.0.1-alpha" properly.
 
 ## Release 1.2.0 (2016-11-04)
 
 ### Added
 
-- #20: Added MustParse function for versions (thanks @adamreese)
-- #15: Added increment methods on versions (thanks @mh-cbon)
+- [#20](https://github.com/Masterminds/semver/issues/20):
+  Added MustParse function for versions (thanks @adamreese)
+- [#15](https://github.com/Masterminds/semver/issues/15):
+  Added increment methods on versions (thanks @mh-cbon)
 
 ### Fixed
 
-- Issue #21: Per the SemVer spec (section 9) a pre-release is unstable and
+- Issue [#21](https://github.com/Masterminds/semver/issues/21):
+  Per the SemVer spec (section 9) a pre-release is unstable and
   might not satisfy the intended compatibility. The change here ignores pre-releases
   on constraint checks (e.g., ~ or ^) when a pre-release is not part of the
   constraint. For example, `^1.2.3` will ignore pre-releases while
@@ -208,20 +259,24 @@ functions. These are described in the added and changed sections below.
 
 ### Changed
 
-- Issue #9: Speed up version comparison performance (thanks @sdboyer)
-- Issue #8: Added benchmarks (thanks @sdboyer)
+- Issue [#9](https://github.com/Masterminds/semver/issues/9):
+  Speed up version comparison performance (thanks @sdboyer)
+- Issue [#8](https://github.com/Masterminds/semver/issues/8):
+  Added benchmarks (thanks @sdboyer)
 - Updated Go Report Card URL to new location
 - Updated Readme to add code snippet formatting (thanks @mh-cbon)
 - Updating tagging to v[SemVer] structure for compatibility with other tools.
 
 ## Release 1.1.0 (2016-03-11)
 
-- Issue #2: Implemented validation to provide reasons a versions failed a
+- Issue [#2](https://github.com/Masterminds/semver/issues/2):
+  Implemented validation to provide reasons a versions failed a
   constraint.
 
 ## Release 1.0.1 (2015-12-31)
 
-- Fixed #1: * constraint failing on valid versions.
+- Fixed [#1](https://github.com/Masterminds/semver/issues/1):
+  - constraint failing on valid versions.
 
 ## Release 1.0.0 (2015-10-20)
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ GOPATH=$(shell go env GOPATH)
 GOLANGCI_LINT=$(GOPATH)/bin/golangci-lint
 
 .PHONY: lint
-lint: $(GOLANGCI_LINT)
+lint: | $(GOLANGCI_LINT)
 	@echo "==> Linting codebase"
 	@$(GOLANGCI_LINT) run
 

--- a/README.md
+++ b/README.md
@@ -1,57 +1,74 @@
 # SemVer
 
-The `semver` package provides the ability to work with [Semantic Versions](http://semver.org) in Go. Specifically it provides the ability to:
+The `semver` package provides the ability
+to work with [Semantic Versions](http://semver.org) in Go.
+Specifically it provides the ability to:
 
 * Parse semantic versions
 * Sort semantic versions
 * Check if a semantic version fits within a set of constraints
 * Optionally work with a `v` prefix
 
-[![Stability:
-Active](https://masterminds.github.io/stability/active.svg)](https://masterminds.github.io/stability/active.html)
-[![](https://github.com/Masterminds/semver/workflows/Tests/badge.svg)](https://github.com/Masterminds/semver/actions)
+[![Tests](https://github.com/wfscheper/semver/workflows/Tests/badge.svg)](https://github.com/wfscheper/semver/actions)
 [![GoDoc](https://img.shields.io/static/v1?label=godoc&message=reference&color=blue)](https://pkg.go.dev/github.com/wfscheper/semver/v4)
-[![Go Report Card](https://goreportcard.com/badge/github.com/Masterminds/semver)](https://goreportcard.com/report/github.com/Masterminds/semver)
-
-If you are looking for a command line tool for version comparisons please see
-[vert](https://github.com/Masterminds/vert) which uses this library.
+[![Go Report Card](https://goreportcard.com/badge/github.com/wfscheper/semver)](https://goreportcard.com/report/github.com/wfscheper/semver)
 
 ## Package Versions
 
-Note, import `github.com/github.com/wfscheper/semver/v4` to use the latest version.
+Note,
+import `github.com/wfscheper/semver/v4` to use the latest version.
 
-There are three major versions fo the `semver` package.
+There are four versions fo the `semver` package.
 
-* 3.x.x is the stable and active version. This version is focused on constraint
-  compatibility for range handling in other tools from other languages. It has
-  a similar API to the v1 releases. The development of this version is on the master
-  branch. The documentation for this version is below.
-* 2.x was developed primarily for [dep](https://github.com/golang/dep). There are
-  no tagged releases and the development was performed by [@sdboyer](https://github.com/sdboyer).
-  There are API breaking changes from v1. This version lives on the [2.x branch](https://github.com/Masterminds/semver/tree/2.x).
-* 1.x.x is the original release. It is no longer maintained. You should use the
-  v3 release instead. You can read the documentation for the 1.x.x release
+* 4.x.x is a hard fork of [Masterminds/semver/v3](https://github.com/Masterminds/semver)
+  to try out eliminating Version and Constraint pointers from the API.
+  The development of this version is on the main branch.
+  The documentation for this version is below.
+* 3.x.x is the stable and active Masterminds version.
+  This version is focused on constraint compatibility
+  for range handling in other tools from other languages.
+  It has a similar API to the v1 releases.
+* 2.x was developed primarily for [dep](https://github.com/golang/dep).
+  There are no tagged releases
+  and the development was performed by [@sdboyer](https://github.com/sdboyer).
+  There are API breaking changes from v1.
+  This version lives on the [2.x branch](https://github.com/Masterminds/semver/tree/2.x).
+* 1.x.x is the original release.
+  It is no longer maintained.
+  You should use the v3 or v4 release instead.
+  You can read the documentation for the 1.x.x release
   [here](https://github.com/Masterminds/semver/blob/release-1/README.md).
 
 ## Parsing Semantic Versions
 
-There are two functions that can parse semantic versions. The `StrictNewVersion`
-function only parses valid version 2 semantic versions as outlined in the
-specification. The `NewVersion` function attempts to coerce a version into a
-semantic version and parse it. For example, if there is a leading v or a version
-listed without all 3 parts (e.g. `v1.2`) it will attempt to coerce it into a valid
-semantic version (e.g., 1.2.0). In both cases a `Version` object is returned
-that can be sorted, compared, and used in constraints.
+There are two functions that can parse semantic versions.
+The `StrictNewVersion` function only parses valid version 2 semantic versions
+as outlined in the specification.
+The `NewVersion` function attempts to coerce a version
+into a semantic version and parse it.
+For example,
+if there is a leading v
+or a version listed without all 3 parts (e.g. `v1.2`)
+it will attempt to coerce it into a valid semantic version (e.g., 1.2.0).
+In both cases a `Version` object is returned that can be
+sorted,
+compared,
+and used in constraints.
 
-When parsing a version an error is returned if there is an issue parsing the
-version. For example,
+When parsing a version an error is returned
+if there is an issue parsing the version.
+For example,
 
-    v, err := semver.NewVersion("1.2.3-beta.1+build345")
+```go
+v, err := semver.NewVersion("1.2.3-beta.1+build345")
+```
 
-The version object has methods to get the parts of the version, compare it to
-other versions, convert the version back into a string, and get the original
-string. Getting the original string is useful if the semantic version was coerced
-into a valid form.
+The version object has methods to get the parts of the version,
+compare it to other versions,
+convert the version back into a string,
+and get the original string.
+Getting the original string is useful
+if the semantic version was coerced into a valid form.
 
 ## Sorting Semantic Versions
 
@@ -60,7 +77,7 @@ For example,
 
 ```go
 raw := []string{"1.2.3", "1.0", "1.3", "2", "0.4.2",}
-vs := make([]*semver.Version, len(raw))
+vs := make([]semver.Version, len(raw))
 for i, r := range raw {
     v, err := semver.NewVersion(r)
     if err != nil {
@@ -75,33 +92,46 @@ sort.Sort(semver.Collection(vs))
 
 ## Checking Version Constraints
 
-There are two methods for comparing versions. One uses comparison methods on
-`Version` instances and the other uses `Constraints`. There are some important
-differences to notes between these two methods of comparison.
+There are two methods for comparing versions.
+One uses comparison methods on `Version` instances
+and the other uses `Constraints`.
+There are some important differences to note
+between these two methods of comparison.
 
-1. When two versions are compared using functions such as `Compare`, `LessThan`,
-   and others it will follow the specification and always include prereleases
-   within the comparison. It will provide an answer that is valid with the
-   comparison section of the spec at https://semver.org/#spec-item-11
-2. When constraint checking is used for checks or validation it will follow a
-   different set of rules that are common for ranges with tools like npm/js
-   and Rust/Cargo. This includes considering prereleases to be invalid if the
-   ranges does not include one. If you want to have it include pre-releases a
-   simple solution is to include `-0` in your range.
-3. Constraint ranges can have some complex rules including the shorthand use of
-   ~ and ^. For more details on those see the options below.
+1. When two versions are compared using functions such as
+   `Compare`,
+   `LessThan`,
+   and others it will follow the specification
+   and always include pre-releases within the comparison.
+   It will provide an answer that is valid
+   with the comparison section of the spec at <https://semver.org/#spec-item-11>
+1. When constraint checking is used for checks or validation
+   it will follow a different set of rules
+   that are common for ranges with tools like npm/js and Rust/Cargo.
+   This includes considering pre-releases to be invalid
+   if the ranges does not include one.
+   If you want to have it include pre-releases
+   a simple solution is to include `-0` in your range.
+1. Constraint ranges can have some complex rules
+   including the shorthand use of ~ and ^.
+   For more details on those see the options below.
 
-There are differences between the two methods or checking versions because the
-comparison methods on `Version` follow the specification while comparison ranges
-are not part of the specification. Different packages and tools have taken it
-upon themselves to come up with range rules. This has resulted in differences.
-For example, npm/js and Cargo/Rust follow similar patterns while PHP has a
-different pattern for ^. The comparison features in this package follow the
-npm/js and Cargo/Rust lead because applications using it have followed similar
-patters with their versions.
+There are differences between the two methods for checking versions,
+because the comparison methods on `Version` follow the specification
+while comparison ranges are not part of the specification.
+Different packages and tools have taken it upon themselves
+to come up with range rules.
+This has resulted in differences.
+For example,
+npm/js and Cargo/Rust follow similar patterns
+while PHP has a different pattern for ^.
+The comparison features in this package
+follow the npm/js and Cargo/Rust lead
+because applications using it
+have followed similar patters with their versions.
 
-Checking a version against version constraints is one of the most featureful
-parts of the package.
+Checking a version against version constraints
+is one of the most featureful parts of the package.
 
 ```go
 c, err := semver.NewConstraint(">= 1.2.3")
@@ -119,11 +149,15 @@ a := c.Check(v)
 
 ### Basic Comparisons
 
-There are two elements to the comparisons. First, a comparison string is a list
-of space or comma separated AND comparisons. These are then separated by || (OR)
-comparisons. For example, `">= 1.2 < 3.0.0 || >= 4.2.3"` is looking for a
-comparison that's greater than or equal to 1.2 and less than 3.0.0 or is
-greater than or equal to 4.2.3.
+There are two elements to the comparisons.
+First,
+a comparison string is a list of space or comma separated AND comparisons.
+These are then separated by || (OR) comparisons.
+For example,
+`">= 1.2 < 3.0.0 || >= 4.2.3"` is looking for a comparison
+that's greater than or equal to 1.2,
+and less than 3.0.0,
+ or is greater than or equal to 4.2.3.
 
 The basic comparisons are:
 
@@ -136,32 +170,47 @@ The basic comparisons are:
 
 ### Working With Prerelease Versions
 
-Pre-releases, for those not familiar with them, are used for software releases
-prior to stable or generally available releases. Examples of prereleases include
-development, alpha, beta, and release candidate releases. A prerelease may be
-a version such as `1.2.3-beta.1` while the stable release would be `1.2.3`. In the
-order of precedence, prereleases come before their associated releases. In this
-example `1.2.3-beta.1 < 1.2.3`.
+Pre-releases,
+for those not familiar with them,
+are used for software releases prior to stable
+or generally available releases.
+Examples of pre-releases include
+development,
+alpha,
+beta,
+and release candidate releases.
+A pre-release may be a version such as `1.2.3-beta.1`
+while the stable release would be `1.2.3`.
+In the order of precedence,
+pre-releases come before their associated releases.
+In this example `1.2.3-beta.1 < 1.2.3`.
 
-According to the Semantic Version specification prereleases may not be
-API compliant with their release counterpart. It says,
+According to the Semantic Version specification
+pre-releases may not be API compliant with their release counterpart.
+It says,
 
 > A pre-release version indicates that the version is unstable and might not satisfy the intended compatibility requirements as denoted by its associated normal version.
 
-SemVer comparisons using constraints without a prerelease comparator will skip
-prerelease versions. For example, `>=1.2.3` will skip prereleases when looking
-at a list of releases while `>=1.2.3-0` will evaluate and find prereleases.
+SemVer comparisons using constraints
+without a pre-release comparator will skip pre-release versions.
+For example,
+`>=1.2.3` will skip pre-releases
+when looking at a list of releases
+while `>=1.2.3-0` will evaluate and find pre-releases.
 
-The reason for the `0` as a pre-release version in the example comparison is
-because pre-releases can only contain ASCII alphanumerics and hyphens (along with
-`.` separators), per the spec. Sorting happens in ASCII sort order, again per the
-spec. The lowest character is a `0` in ASCII sort order
-(see an [ASCII Table](http://www.asciitable.com/))
+The reason for the `0` as a pre-release version in the example comparison
+is because per the spec pre-releases can only contain ASCII alphanumerics
+and hyphens (along with `.` separators).
+Sorting happens in ASCII sort order,
+again per the spec.
+The lowest character in ASCII sort orderis a `0`
+(see an [ASCII Table](http://www.asciitable.com/)).
 
-Understanding ASCII sort ordering is important because A-Z comes before a-z. That
-means `>=1.2.3-BETA` will return `1.2.3-alpha`. What you might expect from case
-sensitivity doesn't apply here. This is due to ASCII sort ordering which is what
-the spec specifies.
+Understanding ASCII sort ordering is important,
+because A-Z comes before a-z.
+That means `>=1.2.3-BETA` will return `1.2.3-alpha`.
+What you might expect from case sensitivity doesn't apply here.
+This is due to ASCII sort ordering which is what the spec specifies.
 
 ### Hyphen Range Comparisons
 
@@ -173,9 +222,11 @@ These look like:
 
 ### Wildcards In Comparisons
 
-The `x`, `X`, and `*` characters can be used as a wildcard character. This works
-for all comparison operators. When used on the `=` operator it falls
-back to the patch level comparison (see tilde below). For example,
+The `x`, `X`, and `*` characters can be used as a wildcard character.
+This works for all comparison operators.
+When used on the `=` operator
+it falls back to the patch level comparison (see tilde below).
+For example,
 
 * `1.2.x` is equivalent to `>= 1.2.0, < 1.3.0`
 * `>= 1.2.x` is equivalent to `>= 1.2.0`
@@ -184,8 +235,9 @@ back to the patch level comparison (see tilde below). For example,
 
 ### Tilde Range Comparisons (Patch)
 
-The tilde (`~`) comparison operator is for patch level ranges when a minor
-version is specified and major level changes when the minor number is missing.
+The tilde (`~`) comparison operator
+is for patch level ranges when a minor version is specified
+and major level changes when the minor number is missing.
 For example,
 
 * `~1.2.3` is equivalent to `>= 1.2.3, < 1.3.0`
@@ -196,10 +248,12 @@ For example,
 
 ### Caret Range Comparisons (Major)
 
-The caret (`^`) comparison operator is for major level changes once a stable
-(1.0.0) release has occurred. Prior to a 1.0.0 release the minor versions acts
-as the API stability level. This is useful when comparisons of API versions as a
-major change is API breaking. For example,
+The caret (`^`) comparison operator
+is for major level changes once a stable (1.0.0) release has occurred.
+Prior to a 1.0.0 release the minor versions acts as the API stability level.
+This is useful for comparisons of API versions,
+as a major change is API breaking.
+For example,
 
 * `^1.2.3` is equivalent to `>= 1.2.3, < 2.0.0`
 * `^1.2.x` is equivalent to `>= 1.2.0, < 2.0.0`
@@ -213,19 +267,22 @@ major change is API breaking. For example,
 
 ## Validation
 
-In addition to testing a version against a constraint, a version can be validated
-against a constraint. When validation fails a slice of errors containing why a
-version didn't meet the constraint is returned. For example,
+In addition to testing a version against a constraint,
+a version can be validated against a constraint.
+When validation fails
+it returns a slice of errors
+containing why a version didn't meet the constraint is returned.
+For example,
 
 ```go
 c, err := semver.NewConstraint("<= 1.2.3, >= 1.4")
 if err != nil {
-    // Handle constraint not being parseable.
+    // Handle constraint not being parsable.
 }
 
 v, err := semver.NewVersion("1.3")
 if err != nil {
-    // Handle version not being parseable.
+    // Handle version not being parsable.
 }
 
 // Validate a version against a constraint.
@@ -242,17 +299,19 @@ for _, m := range msgs {
 
 ## Contribute
 
-If you find an issue or want to contribute please file an [issue](https://github.com/Masterminds/semver/issues)
-or [create a pull request](https://github.com/Masterminds/semver/pulls).
+If you find an issue or want to contribute
+please file an [issue](https://github.com/wfscheper/semver/issues)
+or [create a pull request](https://github.com/wfscheper/semver/pulls).
 
 ## Security
 
-Security is an important consideration for this project. The project currently
-uses the following tools to help discover security issues:
+Security is an important consideration for this project.
+The project currently uses the following tools to help discover security issues:
 
-* [CodeQL](https://github.com/Masterminds/semver)
+* [CodeQL](https://github.com/wfscheper/semver)
 * [gosec](https://github.com/securego/gosec)
 * Daily Fuzz testing
 
-If you believe you have found a security vulnerability you can privately disclose
-it through the [GitHub security page](https://github.com/Masterminds/semver/security).
+If you believe you have found a security vulnerability
+you can privately disclose it
+through the [GitHub security page](https://github.com/wfscheper/semver/security).

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The `semver` package provides the ability to work with [Semantic Versions](http:
 [![Stability:
 Active](https://masterminds.github.io/stability/active.svg)](https://masterminds.github.io/stability/active.html)
 [![](https://github.com/Masterminds/semver/workflows/Tests/badge.svg)](https://github.com/Masterminds/semver/actions)
-[![GoDoc](https://img.shields.io/static/v1?label=godoc&message=reference&color=blue)](https://pkg.go.dev/github.com/Masterminds/semver/v3)
+[![GoDoc](https://img.shields.io/static/v1?label=godoc&message=reference&color=blue)](https://pkg.go.dev/github.com/wfscheper/semver/v4)
 [![Go Report Card](https://goreportcard.com/badge/github.com/Masterminds/semver)](https://goreportcard.com/report/github.com/Masterminds/semver)
 
 If you are looking for a command line tool for version comparisons please see
@@ -18,7 +18,7 @@ If you are looking for a command line tool for version comparisons please see
 
 ## Package Versions
 
-Note, import `github.com/github.com/Masterminds/semver/v3` to use the latest version.
+Note, import `github.com/github.com/wfscheper/semver/v4` to use the latest version.
 
 There are three major versions fo the `semver` package.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,5 +15,5 @@ Fixes are only released for the latest minor version in the form of a patch rele
 ## Reporting a Vulnerability
 
 You can privately disclose a vulnerability through GitHubs
-[private vulnerability reporting](https://github.com/Masterminds/semver/security/advisories)
+[private vulnerability reporting](https://github.com/wfscheper/semver/security/advisories)
 mechanism.

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -15,14 +15,10 @@ func benchNewConstraint(c string, b *testing.B) {
 }
 
 func BenchmarkNewConstraintUnary(b *testing.B) {
-	b.ReportAllocs()
-	b.ResetTimer()
 	benchNewConstraint("=2.0", b)
 }
 
 func BenchmarkNewConstraintTilde(b *testing.B) {
-	b.ReportAllocs()
-	b.ResetTimer()
 	benchNewConstraint("~2.0.0", b)
 }
 

--- a/collection.go
+++ b/collection.go
@@ -3,7 +3,7 @@ package semver
 // Collection is a collection of Version instances and implements the sort
 // interface. See the sort package for more details.
 // https://golang.org/pkg/sort/
-type Collection []*Version
+type Collection []Version
 
 // Len returns the length of a collection. The number of Version instances
 // on the slice.

--- a/collection_test.go
+++ b/collection_test.go
@@ -15,7 +15,7 @@ func TestCollection(t *testing.T) {
 		"0.4.2",
 	}
 
-	vs := make([]*Version, len(raw))
+	vs := make([]Version, len(raw))
 	for i, r := range raw {
 		v, err := NewVersion(r)
 		if err != nil {

--- a/constraints_test.go
+++ b/constraints_test.go
@@ -4,28 +4,26 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"reflect"
 	"testing"
 )
 
 func TestParseConstraint(t *testing.T) {
 	tests := []struct {
 		in  string
-		f   cfunc
 		v   string
 		err bool
 	}{
-		{">= 1.2", constraintGreaterThanEqual, "1.2.0", false},
-		{"1.0", constraintTildeOrEqual, "1.0.0", false},
-		{"foo", nil, "", true},
-		{"<= 1.2", constraintLessThanEqual, "1.2.0", false},
-		{"=< 1.2", constraintLessThanEqual, "1.2.0", false},
-		{"=> 1.2", constraintGreaterThanEqual, "1.2.0", false},
-		{"v1.2", constraintTildeOrEqual, "1.2.0", false},
-		{"=1.5", constraintTildeOrEqual, "1.5.0", false},
-		{"> 1.3", constraintGreaterThan, "1.3.0", false},
-		{"< 1.4.1", constraintLessThan, "1.4.1", false},
-		{"< 40.50.10", constraintLessThan, "40.50.10", false},
+		{">= 1.2", "1.2.0", false},
+		{"1.0", "1.0.0", false},
+		{"foo", "", true},
+		{"<= 1.2", "1.2.0", false},
+		{"=< 1.2", "1.2.0", false},
+		{"=> 1.2", "1.2.0", false},
+		{"v1.2", "1.2.0", false},
+		{"=1.5", "1.5.0", false},
+		{"> 1.3", "1.3.0", false},
+		{"< 1.4.1", "1.4.1", false},
+		{"< 40.50.10", "40.50.10", false},
 	}
 
 	for _, tc := range tests {
@@ -44,12 +42,6 @@ func TestParseConstraint(t *testing.T) {
 
 		if tc.v != c.con.String() {
 			t.Errorf("Incorrect version found on %s", tc.in)
-		}
-
-		f1 := reflect.ValueOf(tc.f)
-		f2 := reflect.ValueOf(constraintOps[c.origfunc])
-		if f1 != f2 {
-			t.Errorf("Wrong constraint found for %s", tc.in)
 		}
 	}
 }

--- a/doc.go
+++ b/doc.go
@@ -26,7 +26,7 @@ parsing the version. For example,
 The version object has methods to get the parts of the version, compare it to
 other versions, convert the version back into a string, and get the original
 string. For more details please see the documentation
-at https://godoc.org/github.com/Masterminds/semver.
+at https://godoc.org/github.com/wfscheper/semver.
 
 # Sorting Semantic Versions
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/Masterminds/semver/v3
+module github.com/wfscheper/semver/v4
 
 go 1.18

--- a/version_test.go
+++ b/version_test.go
@@ -614,7 +614,7 @@ func TestSQLScanner(t *testing.T) {
 	if err != nil {
 		t.Errorf("Error creating version: %s", err)
 	}
-	var s sql.Scanner = x
+	var s sql.Scanner = &x
 	var out *Version
 	var ok bool
 	if out, ok = s.(*Version); !ok {


### PR DESCRIPTION
In Masterminds/semver#11 and Masterminds/semver#15 there were some good
arguments made in favor of changing the API to use value receivers and
function arguments. While Masterminds/semver apparently didn't adopt
this breaking API change, this is an attempt to try it out in a hard
fork.